### PR TITLE
fix: tag enter for macOS / logo css

### DIFF
--- a/static/css/article_detail.css
+++ b/static/css/article_detail.css
@@ -53,12 +53,7 @@ body {
     height: 300px;
 }
 
-span:hover {
-    cursor: pointer;
-    background-color: #f1da72
-}
-
-img:hover {
+.emoticon:hover {
     cursor: pointer;
     background-color: #f1da72
 }

--- a/static/js/article_create.js
+++ b/static/js/article_create.js
@@ -130,7 +130,7 @@ async function PostArticle(formData) {
 
 window.onload = function () {
     // 엔터로 태그 추가
-    searchInput.addEventListener('keydown', function (event) {
+    searchInput.addEventListener('keypress', function (event) {
         if (event.key === 'Enter') {
             event.preventDefault();
             // 엔터 키 입력

--- a/static/js/article_update.js
+++ b/static/js/article_update.js
@@ -159,7 +159,7 @@ window.onload = function () {
 
     let ul = document.getElementById("tag_ul")
 
-    searchInput.addEventListener('keydown', function (event) {
+    searchInput.addEventListener('keypress', function (event) {
         if (event.key === 'Enter') {
             event.preventDefault();
             // 엔터 키 입력

--- a/static/js/comment.js
+++ b/static/js/comment.js
@@ -95,6 +95,7 @@ async function emoticonButtonList(user_emoticon_list, emoticon_popup, emoticonbt
                     const emoticonImage = document.createElement('img')
                     emoticonImage.setAttribute('src', `${image_url}${image.image}`)
                     emoticonImage.setAttribute('style', 'width: 130px; height: 130px; object-fit: cover;')
+                    emoticonImage.setAttribute('class', 'emoticon')
                     // 이모티콘 클릭했을때 입력창에 넣어주기
                     const image_input_box = document.getElementById(use_emoticon)
                     emoticonImage.addEventListener('click', function () {
@@ -132,6 +133,7 @@ async function emoticonButtonList(user_emoticon_list, emoticon_popup, emoticonbt
             userEmoticon.appendChild(userEmoticonButton)
 
             const userEmoticonButtonSpan = document.createElement('span')
+            userEmoticonButtonSpan.setAttribute('class', 'emoticon')
             userEmoticonButtonSpan.innerText = user_emoticon.title
             userEmoticonButton.appendChild(userEmoticonButtonSpan)
         });
@@ -217,6 +219,7 @@ async function commentUpdate(comment_id) {
 
     const updateCommentEmoticon = document.createElement('img')
     updateCommentEmoticon.setAttribute('style', 'width: 130px; height: 130px; object-fit: cover; margin: auto;')
+    updateCommentEmoticon.setAttribute('class', 'emoticon')
     updateCommentEmoticon.setAttribute('id', 'update_use_emoticon')
     if (commentUsedEmoticonSrc == undefined) {
         updateCommentEmoticon.removeAttribute('src')
@@ -430,6 +433,7 @@ async function commentView() {
             } else {
                 commentEmoticon.setAttribute('src', `${image_url}${element.emoticon_image}`)
                 commentEmoticon.setAttribute('style', 'width: 130px; height: 130px; object-fit: cover;')
+                commentEmoticon.setAttribute('class', 'emoticon')
                 commentEmoticon.setAttribute('id', `comment_use_emoticon${element.use_emoticon}`)
                 commentEmoticon.setAttribute('alt', `${element.use_emoticon}`)
                 commentDiv.appendChild(commentEmoticon)

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -8,6 +8,7 @@ function putEmoji(emojidiv_id, input_id){
         const emojiIconSpan = document.createElement('span')
         emojiIconSpan.textContent = element
         emojiIconSpan.setAttribute('style','font-size: 30px')
+        emojiIconSpan.setAttribute('class','emoticon')
         emojiBox.appendChild(emojiIconSpan)
     });
 


### PR DESCRIPTION
맥OS 태그 입력시 끝글자 추가생성되는 버그 픽스 - 맥에서 확인 필요
상세페이지에서 메인로고 css 겹치는거 수정